### PR TITLE
Updated ruleset testVersion to 7.0 and downgraded wp-coding-standards/wpcs to maximum compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "php": ">=5.6.0,<8.0.0-dev",
     "squizlabs/php_codesniffer": "^3.0",
     "phpcompatibility/php-compatibility": "*",
-    "wp-coding-standards/wpcs": "*"
+    "wp-coding-standards/wpcs": "^2.3.0"
   },
   "type": "phpcodesniffer-standard"
 }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -5,7 +5,7 @@
   <ini name="memory_limit" value="-1"/>
 
   <!-- PHP Version Compatibility -->
-  <config name="testVersion" value="5.6-"/>
+  <config name="testVersion" value="7.0-"/>
   <rule ref="PHPCompatibility"/>
 
   <!-- Generic PHP Standards -->


### PR DESCRIPTION
Issue - https://github.com/elegantthemes/marketplace-phpcs/issues/7

In the latest update, the ruleset `testVersion` has been upgraded to `7.0` to leverage the latest enhancements and optimizations. 

Additionally, to ensure compatibility and streamline development processes, the wp-coding-standards/wpcs package has been downgraded to its maximum compatible version, utilizing the Caret Version Range (^). As a result, the version of wp-coding-standards/wpcs now stands at `^2.3.0`. This means it will always be below then `3.0.0`

I've tested and it's working for me perfectly.