### PR TITLE
D5 :: Marketplace PHPCSS :: Allow PHP 7.4 code to pass sniffs

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -5,7 +5,7 @@
   <ini name="memory_limit" value="-1"/>
 
   <!-- PHP Version Compatibility -->
-  <config name="testVersion" value="7.2-"/>
+  <config name="testVersion" value="7.4-"/>
   <rule ref="PHPCompatibility"/>
 
   <!-- Generic PHP Standards -->


### PR DESCRIPTION
Fixes -  https://github.com/elegantthemes/marketplace-phpcs/issues/12
Fixes - https://github.com/elegantthemes/Divi/issues/42209


Upgraded PHP minimum support is `7.4`.