### PR TITLE
43719 add backticks security sniff

### DIFF
--- a/Sniffs/Security/BackticksSniff.php
+++ b/Sniffs/Security/BackticksSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WordPress Coding Standard.
+ * WordPress Coding Standard for Backticks.
  *
  * @package WPCS\WordPressCodingStandards
  * @link    https://github.com/WordPress/WordPress-Coding-Standards
@@ -13,19 +13,27 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * Flag usage of backticks in PHP code which automatically gets converted to shell_exec calls.
+ * Backticks detection with better error handling and auto-fixing.
  *
  * @package WPCS\WordPressCodingStandards
  * @since   1.0.0
  */
-class BackticksSniff implements Sniff {
+class ImprovedBackticksSniff implements Sniff
+{
+    /**
+     * Track processed backticks to avoid duplicate errors.
+     *
+     * @var array
+     */
+    private $processedBackticks = [];
 
     /**
      * Returns the token types that this sniff is interested in.
      *
-     * @return array(int)
+     * @return array<int>
      */
-    public function register() {
+    public function register()
+    {
         return [T_BACKTICK];
     }
 
@@ -37,22 +45,182 @@ class BackticksSniff implements Sniff {
      *
      * @return void
      */
-    public function process(File $phpcsFile, $stackPtr) {
-        $tokens = $phpcsFile->getTokens();
-        
-        // Find the closing backtick
-        $closer = $phpcsFile->findNext(T_BACKTICK, $stackPtr + 1);
-        if (!$closer) {
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        // Reset processed backticks for each file
+        $filename = $phpcsFile->getFilename();
+        if (!isset($this->processedBackticks[$filename])) {
+            $this->processedBackticks[$filename] = [];
+        }
+
+        // Skip if already processed
+        if (in_array($stackPtr, $this->processedBackticks[$filename], true)) {
             return;
         }
 
-        // Get the content between backticks
-        $content = '';
-        for ($i = $stackPtr + 1; $i < $closer; $i++) {
-            $content .= $tokens[$i]['content'];
+        $tokens = $phpcsFile->getTokens();
+
+        // Check if backtick is inside a string (shouldn't trigger)
+        if ($this->isInsideString($phpcsFile, $stackPtr)) {
+            return;
         }
 
-        $error = 'Usage of backticks is not allowed as it gets converted to shell_exec() calls. This can be a security risk.';
-        $phpcsFile->addError($error, $stackPtr, 'BackticksNotAllowed');
+        // Find the closing backtick
+        $closer = $this->findClosingBacktick($phpcsFile, $stackPtr);
+        
+        if ($closer === false) {
+            $error = 'Unclosed backtick found. This will cause a parse error and is a security risk.';
+            $phpcsFile->addError($error, $stackPtr, 'UnclosedBacktick');
+            return;
+        }
+
+        // Mark both backticks as processed
+        $this->processedBackticks[$filename][] = $stackPtr;
+        $this->processedBackticks[$filename][] = $closer;
+
+        // Get the command content
+        $content = $this->getBacktickContent($phpcsFile, $stackPtr, $closer);
+        
+        // Create detailed error message
+        $command = trim($content);
+        if (empty($command)) {
+            $error = 'Empty backticks found. Use shell_exec() with proper validation instead.';
+        } else {
+            $error = sprintf(
+                'Backticks execute shell command "%s". Use shell_exec() with proper sanitization instead.',
+                $this->truncateCommand($command)
+            );
+        }
+
+        // Add fixable error
+        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'BackticksNotAllowed');
+        
+        if ($fix === true) {
+            $this->applyAutoFix($phpcsFile, $stackPtr, $closer, $content);
+        }
     }
-} 
+
+    /**
+     * Check if backtick is inside a string literal.
+     *
+     * @param File $phpcsFile The file being processed.
+     * @param int  $stackPtr  The position of the backtick.
+     *
+     * @return bool
+     */
+    private function isInsideString(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        
+        // Look backwards for string delimiters
+        $stringTokens = [T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING, T_HEREDOC, T_NOWDOC];
+        
+        for ($i = $stackPtr - 1; $i >= 0; $i--) {
+            if (in_array($tokens[$i]['code'], $stringTokens, true)) {
+                return true;
+            }
+            // Stop at statement boundaries
+            if ($tokens[$i]['code'] === T_SEMICOLON || $tokens[$i]['line'] < $tokens[$stackPtr]['line']) {
+                break;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Find the matching closing backtick.
+     *
+     * @param File $phpcsFile The file being processed.
+     * @param int  $stackPtr  The position of the opening backtick.
+     *
+     * @return int|false The position of the closing backtick or false if not found.
+     */
+    private function findClosingBacktick(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $opener = $stackPtr;
+        
+        // Find next backtick on the same logical line or nearby lines
+        for ($i = $stackPtr + 1; $i < $phpcsFile->numTokens; $i++) {
+            if ($tokens[$i]['code'] === T_BACKTICK) {
+                return $i;
+            }
+            
+            // Stop searching if we've gone too far
+            if ($tokens[$i]['line'] > $tokens[$opener]['line'] + 5) {
+                break;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Get content between backticks.
+     *
+     * @param File $phpcsFile The file being processed.
+     * @param int  $opener    The opening backtick position.
+     * @param int  $closer    The closing backtick position.
+     *
+     * @return string
+     */
+    private function getBacktickContent(File $phpcsFile, $opener, $closer)
+    {
+        if ($closer <= $opener + 1) {
+            return '';
+        }
+        
+        return $phpcsFile->getTokensAsString($opener + 1, $closer - $opener - 1);
+    }
+
+    /**
+     * Truncate command for error message.
+     *
+     * @param string $command The command to truncate.
+     *
+     * @return string
+     */
+    private function truncateCommand($command)
+    {
+        $maxLength = 50;
+        if (strlen($command) > $maxLength) {
+            return substr($command, 0, $maxLength) . '...';
+        }
+        return $command;
+    }
+
+    /**
+     * Apply automatic fix by converting backticks to shell_exec().
+     *
+     * @param File   $phpcsFile The file being processed.
+     * @param int    $opener    The opening backtick position.
+     * @param int    $closer    The closing backtick position.
+     * @param string $content   The content between backticks.
+     *
+     * @return void
+     */
+    private function applyAutoFix(File $phpcsFile, $opener, $closer, $content)
+    {
+        $phpcsFile->fixer->beginChangeset();
+        
+        // Replace opening backtick with shell_exec('
+        $phpcsFile->fixer->replaceToken($opener, "shell_exec('");
+        
+        // Escape any single quotes in the content
+        $escapedContent = str_replace("'", "\\'", $content);
+        
+        // Replace content if it needs escaping
+        if ($escapedContent !== $content) {
+            for ($i = $opener + 1; $i < $closer; $i++) {
+                $phpcsFile->fixer->replaceToken($i, '');
+            }
+            $phpcsFile->fixer->addContent($opener, $escapedContent);
+        }
+        
+        // Replace closing backtick with ')
+        $phpcsFile->fixer->replaceToken($closer, "')");
+        
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/Sniffs/Security/BackticksSniff.php
+++ b/Sniffs/Security/BackticksSniff.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * WordPress Coding Standard.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @link    https://github.com/WordPress/WordPress-Coding-Standards
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace ET\ElegantThemes\Sniffs\Security;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Flag usage of backticks in PHP code which automatically gets converted to shell_exec calls.
+ *
+ * @package WPCS\WordPressCodingStandards
+ * @since   1.0.0
+ */
+class BackticksSniff implements Sniff {
+
+    /**
+     * Returns the token types that this sniff is interested in.
+     *
+     * @return array(int)
+     */
+    public function register() {
+        return [T_BACKTICK];
+    }
+
+    /**
+     * Processes the tokens that this sniff is interested in.
+     *
+     * @param File $phpcsFile The file where the token was found.
+     * @param int  $stackPtr  The position in the stack where the token was found.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr) {
+        $tokens = $phpcsFile->getTokens();
+        
+        // Find the closing backtick
+        $closer = $phpcsFile->findNext(T_BACKTICK, $stackPtr + 1);
+        if (!$closer) {
+            return;
+        }
+
+        // Get the content between backticks
+        $content = '';
+        for ($i = $stackPtr + 1; $i < $closer; $i++) {
+            $content .= $tokens[$i]['content'];
+        }
+
+        $error = 'Usage of backticks is not allowed as it gets converted to shell_exec() calls. This can be a security risk.';
+        $phpcsFile->addError($error, $stackPtr, 'BackticksNotAllowed');
+    }
+} 

--- a/Sniffs/Security/BackticksSniff.php
+++ b/Sniffs/Security/BackticksSniff.php
@@ -13,12 +13,12 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
 /**
- * Backticks detection with better error handling and auto-fixing.
+ * Backticks detection with strict error reporting.
  *
  * @package WPCS\WordPressCodingStandards
  * @since   1.0.0
  */
-class ImprovedBackticksSniff implements Sniff
+class BackticksSniff implements Sniff
 {
     /**
      * Track processed backticks to avoid duplicate errors.
@@ -84,20 +84,16 @@ class ImprovedBackticksSniff implements Sniff
         // Create detailed error message
         $command = trim($content);
         if (empty($command)) {
-            $error = 'Empty backticks found. Use shell_exec() with proper validation instead.';
+            $error = 'Empty backticks found. Backticks are not allowed - remove them entirely.';
         } else {
             $error = sprintf(
-                'Backticks execute shell command "%s". Use shell_exec() with proper sanitization instead.',
+                'Backticks execute shell command "%s". Backticks are not allowed - use proper alternatives like shell_exec() with validation or remove the command entirely.',
                 $this->truncateCommand($command)
             );
         }
 
-        // Add fixable error
-        $fix = $phpcsFile->addFixableError($error, $stackPtr, 'BackticksNotAllowed');
-        
-        if ($fix === true) {
-            $this->applyAutoFix($phpcsFile, $stackPtr, $closer, $content);
-        }
+        // Add non-fixable error - developer must manually resolve
+        $phpcsFile->addError($error, $stackPtr, 'BackticksNotAllowed');
     }
 
     /**
@@ -188,39 +184,5 @@ class ImprovedBackticksSniff implements Sniff
             return substr($command, 0, $maxLength) . '...';
         }
         return $command;
-    }
-
-    /**
-     * Apply automatic fix by converting backticks to shell_exec().
-     *
-     * @param File   $phpcsFile The file being processed.
-     * @param int    $opener    The opening backtick position.
-     * @param int    $closer    The closing backtick position.
-     * @param string $content   The content between backticks.
-     *
-     * @return void
-     */
-    private function applyAutoFix(File $phpcsFile, $opener, $closer, $content)
-    {
-        $phpcsFile->fixer->beginChangeset();
-        
-        // Replace opening backtick with shell_exec('
-        $phpcsFile->fixer->replaceToken($opener, "shell_exec('");
-        
-        // Escape any single quotes in the content
-        $escapedContent = str_replace("'", "\\'", $content);
-        
-        // Replace content if it needs escaping
-        if ($escapedContent !== $content) {
-            for ($i = $opener + 1; $i < $closer; $i++) {
-                $phpcsFile->fixer->replaceToken($i, '');
-            }
-            $phpcsFile->fixer->addContent($opener, $escapedContent);
-        }
-        
-        // Replace closing backtick with ')
-        $phpcsFile->fixer->replaceToken($closer, "')");
-        
-        $phpcsFile->fixer->endChangeset();
     }
 }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -82,13 +82,7 @@
   <rule ref="WordPress.Security.PluginMenuSlug"/>
   <rule ref="WordPress.Security.SafeRedirect"/>
   <!--  <rule ref="WordPress.Security.ValidatedSanitizedInput"/>-->
-
-  <!-- Custom Security Standards -->
-  <rule ref="./phpcs/ElegantThemesMarketplace/Sniffs/Security/BackticksSniff.php">
-    <type>error</type>
-    <message>Usage of backticks is not allowed as it gets converted to shell_exec() calls. This can be a security risk.</message>
-  </rule>
-
+  
   <!-- Wordpress WP Standards -->
   <config name="minimum_supported_wp_version" value="4.6"/>
   <rule ref="WordPress.WP.AlternativeFunctions"/>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -84,7 +84,7 @@
   <!--  <rule ref="WordPress.Security.ValidatedSanitizedInput"/>-->
 
   <!-- Custom Security Standards -->
-  <rule ref="ET.ElegantThemes.Security.BackticksSniff">
+  <rule ref="./phpcs/ElegantThemesMarketplace/Sniffs/Security/BackticksSniff.php">
     <type>error</type>
     <message>Usage of backticks is not allowed as it gets converted to shell_exec() calls. This can be a security risk.</message>
   </rule>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -83,6 +83,12 @@
   <rule ref="WordPress.Security.SafeRedirect"/>
   <!--  <rule ref="WordPress.Security.ValidatedSanitizedInput"/>-->
 
+  <!-- Custom Security Standards -->
+  <rule ref="ET.ElegantThemes.Security.BackticksSniff">
+    <type>error</type>
+    <message>Usage of backticks is not allowed as it gets converted to shell_exec() calls. This can be a security risk.</message>
+  </rule>
+
   <!-- Wordpress WP Standards -->
   <config name="minimum_supported_wp_version" value="4.6"/>
   <rule ref="WordPress.WP.AlternativeFunctions"/>


### PR DESCRIPTION
# Overview
This PR introduces a new security-focused PHP CodeSniffer sniff (`BackticksSniff.php`) that detects and prevents the use of backticks for shell command execution in PHP code. The sniff helps enforce secure coding practices by identifying potential command injection vulnerabilities and providing automatic fixes.

## What Changed
- Added new `BackticksSniff.php` class that implements PHP_CodeSniffer's Sniff interface
- Implemented detection of backtick usage for shell command execution
- Added automatic fixing capability to convert backticks to `shell_exec()` with proper escaping
- Included comprehensive error handling for unclosed backticks and empty commands
- Added support for detecting backticks within string literals to avoid false positives

## How to Test
1. Add these snippets to any plugins fiels you have.
```php
$output = `ls -la`;
$date = `date`;
$user = `whoami`;
$combined = `echo $date` . `echo $user`;
$empty = ``;
$unclosed = `ls -la
$in_string = "This `backtick` is in a string";
$escaped = `echo \`nested\``;
```
2. Run ` ./utils -i {prodcuts_id} for example
```bash
./utils -i 592
```
3. Check the `592-phpcs.html` you should see these errors:
```
FILE: includes/DiviTestimonialExtended.php
On line: 329 Backticks execute shell command "ls -la". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 330 Backticks execute shell command "date". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 331 Backticks execute shell command "whoami". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 332 Backticks execute shell command "echo $date". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 332 Backticks execute shell command "echo $user". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 333 Empty backticks found. Use shell_exec() with proper validation instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 334 Backticks execute shell command "ls -la\n$in_string = "This". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 335 PHP syntax error: syntax error, unexpected identifier "backtick" Generic.PHP.Syntax.PHPSyntax
On line: 335 Backticks execute shell command "is in a string";\n$escaped =". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
On line: 336 All output should be run through an escaping function (see the Security sections in the WordPress Developer Handbooks), found '`'. WordPress.Security.EscapeOutput.OutputNotEscaped
On line: 336 Backticks execute shell command "nested\`". Use shell_exec() with proper sanitization instead. ElegantThemes.Security.ImprovedBackticks.BackticksNotAllowed
```

## screen recording

https://github.com/user-attachments/assets/e869dd65-56ce-49b8-b52b-7be66bc3894c




## Changelog Copy
New BackticksSniff for detecting and preventing shell command execution via backticks.